### PR TITLE
Adds migrate command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,6 @@ npx sanity-template check
 This will copy files from the `template` directory into the `build` (which should be gitignored). The files in the `build` directory will have template variables replaced (`<#<varName>#>`).
 
 
-### `migrate`
-
-The `migrate` method is a helper function to convert a template from v1 to v2. When run in the CLI, it will modify the `sanity-template.json` file to match the syntax required for v2.
-
-```sh
-npx sanity-template migrate
-```
 
 ### Node.js API
 
@@ -98,6 +91,15 @@ check({
   })
 ```
 
+### Migrate from v1 to v2 
+
+#### `migrate`
+
+The `migrate` method is a helper function to convert a template from v1 to v2. When run in the CLI, it will modify the `sanity-template.json` file to match the syntax required for v2.
+
+```sh
+npx sanity-template migrate
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ npx sanity-template check
 
 This will copy files from the `template` directory into the `build` (which should be gitignored). The files in the `build` directory will have template variables replaced (`<#<varName>#>`).
 
+
+### `migrate`
+
+The `migrate` method is a helper function to convert a template from v1 to v2. When run in the CLI, it will modify the `sanity-template.json` file to match the syntax required for v2.
+
+```sh
+npx sanity-template migrate
+```
+
 ### Node.js API
 
 #### `build`
@@ -88,6 +97,7 @@ check({
     }
   })
 ```
+
 
 ## License
 


### PR DESCRIPTION
Adds the `migrate` command to the readme to match up with having it in the --help flag. 

Added it to bottom as its own section, since it should be an edge case for people